### PR TITLE
Update to td_agent and plugins to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN ulimit -n 65536
 
 # Disable prompts from apt.
 ENV DEBIAN_FRONTEND noninteractive
-ENV TD_AGENT_VERSION 2.3.5
+ENV TD_AGENT_VERSION 3.1.1
 
 # Copy the Fluentd configuration file.
 COPY td-agent.conf /etc/td-agent/td-agent.conf

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # docker-fluentd
 Fluentd image with added plugins:
 
-* fluent-plugin-kubernetes_metadata_filter -v 0.27.0
-* fluent-plugin-elasticsearch -v 1.9.5
+* fluent-plugin-kubernetes_metadata_filter -v 0.31.0
+* fluent-plugin-elasticsearch -v 2.6.1
 * fluent-plugin-dogstatsd -v 0.0.6
 * fluent-plugin-forest -v 0.3.3
-* fluent-plugin-multi-format-parser -v 0.1.1
+* fluent-plugin-multi-format-parser -v 1.0.0

--- a/build.sh
+++ b/build.sh
@@ -30,11 +30,11 @@ sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/in
 
 # Install the Elasticsearch Fluentd plug-in.
 # http://docs.fluentd.org/articles/plugin-management
-td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.27.0
-td-agent-gem install --no-document fluent-plugin-elasticsearch -v 1.9.5
+td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.31.0
+td-agent-gem install --no-document fluent-plugin-elasticsearch -v 2.6.1
 td-agent-gem install --no-document fluent-plugin-dogstatsd -v 0.0.6
 td-agent-gem install --no-document fluent-plugin-forest -v 0.3.3
-td-agent-gem install --no-document fluent-plugin-multi-format-parser -v 0.1.1
+td-agent-gem install --no-document fluent-plugin-multi-format-parser -v 1.0.0
 
 # Remove docs and postgres references
 rm -rf /opt/td-agent/embedded/share/doc \


### PR DESCRIPTION
An encounter with duplicate messaging, similar to [this reported
issue][1] prompted the need to update fluent-plugin-elasticsearch, which
in turn made updating fluentd (td_agent) necessary.

[1]: https://github.com/uken/fluent-plugin-elasticsearch/issues/312