### PR TITLE
Upgrade fluent-plugin-kubernetes_metadata_filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # docker-fluentd
 Fluentd image with added plugins:
 
-* fluent-plugin-kubernetes_metadata_filter -v 0.31.0
+* fluent-plugin-kubernetes_metadata_filter -v 1.0.1
 * fluent-plugin-elasticsearch -v 2.6.1
 * fluent-plugin-dogstatsd -v 0.0.6
 * fluent-plugin-forest -v 0.3.3

--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,7 @@ sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/in
 
 # Install the Elasticsearch Fluentd plug-in.
 # http://docs.fluentd.org/articles/plugin-management
-td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 0.31.0
+td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 1.0.1
 td-agent-gem install --no-document fluent-plugin-elasticsearch -v 2.6.1
 td-agent-gem install --no-document fluent-plugin-dogstatsd -v 0.0.6
 td-agent-gem install --no-document fluent-plugin-forest -v 0.3.3


### PR DESCRIPTION
Seeing this in logs:
```
2018-02-23 12:18:04 +0000 [warn]: #0 emit transaction failed:
error_class=NoMethodError error="undefined method `count' for
nil:NilClass"
location="/opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-kubernetes_metadata_filter-0.31.0/lib/fluent/plugin/filter_kubernetes_metadata.rb:140:in
`dump_stats'"
tag="kubernetes.var.log.containers.tracktor-731105374-f2mrk_default_tracktor-213ae4e17bde22c9906fa50cfc806f137f65ef3234c4724258d7206f53d4b967.log"
```