### PR TITLE
Install necessary systemd plugin dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ set -eux
 
 
 # Install prerequisites.
-clean-install curl ca-certificates make g++ sudo bash gnupg
+clean-install curl ca-certificates make g++ sudo bash gnupg libsystemd0
 
 # Install Fluentd.
 /usr/bin/curl -sSL https://toolbelt.treasuredata.com/sh/install-debian-stretch-td-agent3.sh | sh


### PR DESCRIPTION
According to [the plugin docs][1]:

> This plugin depends on libsystemd. On Debian or Ubuntu you might need to
install the libsystemd0 package: `apt-get install libsystemd0`

Without this the plugin usage will currently fail with:
```
/opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/ffi-1.10.0/lib/ffi/library.rb:145:in `block in ffi_lib': Could not open library 'libsystemd.so.0': libsystemd.so.0: cannot open shared object file: No such file or directory. (LoadError)
Could not open library 'libsystemd.so': libsystemd.so: cannot open shared object file: No such file or directory.
Could not open library 'libsystemd-id128.so.0': libsystemd-id128.so.0: cannot open shared object file: No such file or directory.
Could not open library 'libsystemd-id128.so': libsystemd-id128.so: cannot open shared object file: No such file or directory
        from /opt/td-agent/embedded/lib/ruby/gems/2.4.0/gems/ffi-1.10.0/lib/ffi/library.rb:99:in `map'
        ...
```

[1]: https://github.com/reevoo/fluent-plugin-systemd#dependencies