### PR TITLE
Upgrade fluentd-plugin-kubernetes_metadata_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # docker-fluentd
 Fluentd image with added plugins:
 
-* fluent-plugin-kubernetes_metadata_filter -v 1.0.1
-* fluent-plugin-elasticsearch -v 2.6.1
+* fluent-plugin-kubernetes_metadata_filter -v 2.5.2
+* fluent-plugin-elasticsearch -v 3.5.2
 * fluent-plugin-dogstatsd -v 0.0.6
-* fluent-plugin-forest -v 0.3.3
 * fluent-plugin-multi-format-parser -v 1.0.0
-* fluent-plugin-record-modifier -v 1.0.2
+* fluent-plugin-record-modifier -v 2.0.1
+* fluent-plugin-systemd -v 1.0.2

--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/in
 
 # Install the Elasticsearch Fluentd plug-in.
 # http://docs.fluentd.org/articles/plugin-management
-td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 2.1.6
+td-agent-gem install --no-document fluent-plugin-kubernetes_metadata_filter -v 2.5.2
 td-agent-gem install --no-document fluent-plugin-elasticsearch -v 3.5.2
 td-agent-gem install --no-document fluent-plugin-dogstatsd -v 0.0.6
 td-agent-gem install --no-document fluent-plugin-multi-format-parser -v 1.0.0


### PR DESCRIPTION
The new version supports `pod_ip` field.

Also updated README as it was outdated.