### PR TITLE
Initial configuration for renovate bot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-inf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=fluent/fluentd
 ARG FLUENTD_VERSION=1.4.2
 FROM fluent/fluentd:v${FLUENTD_VERSION}-debian-2.0
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dependencyDashboard": true,
+  "dependencyDashboardAutoclose": true,
+  "assigneesFromCodeOwners": true,
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Docker file dependencies (non-major)"
+    },
+    {
+      "matchManagers": ["bundler"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Ruby gems (non-major)"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "(.+/)?Dockerfile$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: lookupName=(?<lookupName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) .+?_VERSION=(?<currentValue>.+?)\\s"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
We are enabling here:
* ruby gem manager
* docker custom manager (regex) to update variables inside docker file

Next steps to activate it:
* add repo name to sm-configuration/kubernetes/environment/acceptance/helm/renovate-bot.yaml
* deploy changes
* trigger execution of bot manually, or wait till the next run
`kubectl --context=acceptance -n support create job --from=cronjob/renovate-bot renovate-bot-manual-$(date +%Y-%m-%d-%H-%M-%S)`

Signed-off-by: Vladimir Kuznichenkov <vladimir.kuznichenkov@glia.com>